### PR TITLE
CoC: add committee members to CoC text

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -37,7 +37,9 @@ when an individual is representing the project or its community.
 A working group of community members is committed to promptly addressing any
 reported issues. The working group is made up of pandas contributors and users.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the working group. The working group currently includes
+reported by contacting the working group by e-mail (pandas-coc@googlegroups.com).
+Messages sent to this e-mail address will not be publicly visible but only to
+the working group members. The working group currently includes
 
 - Safia Abdalla
 - Tom Augspurger

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -39,7 +39,11 @@ reported issues. The working group is made up of pandas contributors and users.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the working group. The working group currently includes
 
-- member / email
+- Safia Abdalla
+- Tom Augspurger
+- Joris Van den Bossche
+- Camille Scott
+- Nathaniel Smith
 
 All complaints will be reviewed and investigated and will result in a response
 that is deemed necessary and appropriate to the circumstances. Maintainers are

--- a/people.md
+++ b/people.md
@@ -31,6 +31,6 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 
 - Safia Abdalla
 - Tom Augspurger
-- Joris van den Bossche
+- Joris Van den Bossche
 - Camille Scott
 - Nathaniel Smith


### PR DESCRIPTION
Solving https://github.com/pydata/pandas-governance/commit/1376493cdbfaa22adebd72cf1891db415f9f6923#commitcomment-18587703

But, we also have to decide on how people can contact those members. So either adding the email addresses of the different people listed there, or making a generic email address that is forwarded to those people. 